### PR TITLE
Fix 0 transition calculation time taken exception

### DIFF
--- a/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_CrossDissolve.java
+++ b/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_CrossDissolve.java
@@ -107,7 +107,9 @@ public class Trans_CrossDissolve extends ColemanTransition
 			int prevFps = fps;
 			
 			//set fps to how many frames of the average elapsed time will fit into one second
-			fps = Math.min(Math.max(Math.round(1000 / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			if (avgElapsedTime != 0)
+				fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			else fps = 60;//so fast that it didn't even take a full millisecond on average
 			
 			//System.out.println("timeInc: " + timeInc + " avgElapsedTime: " + avgElapsedTime + "\nprevFps: " + prevFps + " fps: " + fps);
 		}

--- a/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeDown.java
+++ b/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeDown.java
@@ -101,7 +101,9 @@ public class Trans_WipeDown extends ColemanTransition
 			int prevFps = fps;
 
 			//set fps to how many frames of the average elapsed time will fit into one second
-			fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			if (avgElapsedTime != 0)
+				fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			else fps = 60;//so fast that it didn't even take a full millisecond on average
 			
 			//System.out.println("timeInc: " + timeInc + " avgElapsedTime: " + avgElapsedTime + "\nprevFps: " + prevFps + " fps: " + fps);
 		}

--- a/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeLeft.java
+++ b/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeLeft.java
@@ -106,7 +106,9 @@ public class Trans_WipeLeft extends ColemanTransition
 			int prevFps = fps;
 
 			//set fps to how many frames of the average elapsed time will fit into one second
-			fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			if (avgElapsedTime != 0)
+				fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			else fps = 60;//so fast that it didn't even take a full millisecond on average
 			
 			//System.out.println("timeInc: " + timeInc + " avgElapsedTime: " + avgElapsedTime + "\nprevFps: " + prevFps + " fps: " + fps);
 		}

--- a/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeRight.java
+++ b/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeRight.java
@@ -101,7 +101,9 @@ public class Trans_WipeRight extends ColemanTransition
 			int prevFps = fps;
 
 			//set fps to how many frames of the average elapsed time will fit into one second
-			fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			if (avgElapsedTime != 0)
+				fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			else fps = 60;//so fast that it didn't even take a full millisecond on average
 			
 			//System.out.println("timeInc: " + timeInc + " avgElapsedTime: " + avgElapsedTime + "\nprevFps: " + prevFps + " fps: " + fps);
 		}

--- a/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeUp.java
+++ b/Slideshow-Creator/src/pkgImageTransitions/Transitions/Trans_WipeUp.java
@@ -79,6 +79,7 @@ public class Trans_WipeUp extends ColemanTransition
 			// Draw part of B into A
 			gA.drawImage(contImageB, 0, startDraw, imgWidth, endDraw, 0, startDraw, imgWidth, endDraw, null); // Draw portion of ImageB into ImageA
 			gPan.drawImage(contImageA, 0, 0, imgPanel);
+			
 			// Pause a bit
 			try 
 			{
@@ -100,7 +101,9 @@ public class Trans_WipeUp extends ColemanTransition
 			int prevFps = fps;
 
 			//set fps to how many frames of the average elapsed time will fit into one second
-			fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			if (avgElapsedTime != 0)
+				fps = Math.min(Math.max(Math.round(timeMillis / avgElapsedTime), 5), 60);//limit framerate to between 5 and 60 fps
+			else fps = 60;//so fast that it didn't even take a full millisecond on average
 			
 			//System.out.println("timeInc: " + timeInc + " avgElapsedTime: " + avgElapsedTime + "\nprevFps: " + prevFps + " fps: " + fps);
 		}


### PR DESCRIPTION
Fixed a divide by zero error when transitions are so fast that the average milliseconds spent calculating is 0.